### PR TITLE
perf: simplify runtime - every/some over findIndex

### DIFF
--- a/src/guardAllIn.ts
+++ b/src/guardAllIn.ts
@@ -32,9 +32,7 @@ type GuardAllIn = <Guards extends readonly AnyTypeGuard[]>(
  */
 const guardAllIn: GuardAllIn = (guards) =>
   ((value) =>
-    guards.findIndex((guard) => !guard(value)) === -1) as GuardAllInFn<
-    typeof guards
-  >;
+    guards.every((guard) => guard(value))) as GuardAllInFn<typeof guards>;
 
 export { guardAllIn };
 export type { GuardAllInFn, GuardAllIn };

--- a/src/guardEitherIn.ts
+++ b/src/guardEitherIn.ts
@@ -27,7 +27,7 @@ type GuardEitherIn = <Guards extends readonly AnyTypeGuard[]>(
 const guardEitherIn: GuardEitherIn =
   (guards) =>
   (value): value is never =>
-    guards.findIndex((guard) => guard(value)) !== -1;
+    guards.some((guard) => guard(value));
 
 export { guardEitherIn };
 export type { GuardEitherIn };

--- a/src/isNonEmptyArray.ts
+++ b/src/isNonEmptyArray.ts
@@ -1,4 +1,3 @@
-import { isArray } from './isArray';
 import type { TypeGuardFn } from './types';
 
 /**
@@ -9,6 +8,6 @@ import type { TypeGuardFn } from './types';
 const isNonEmptyArray: TypeGuardFn<
   unknown,
   readonly [unknown, ...unknown[]]
-> = (value): value is never => isArray(value) && value.length > 0;
+> = (value): value is never => Array.isArray(value) && value.length > 0;
 
 export { isNonEmptyArray };

--- a/src/matchExactSchema.ts
+++ b/src/matchExactSchema.ts
@@ -46,10 +46,10 @@ type MatchExactSchema = <Schema extends TypeGuardSchema>(
 const matchExactSchema: MatchExactSchema =
   (schema) =>
   (value): value is never =>
-    Object.keys(value).findIndex((key) => !(key in schema)) === -1 &&
-    Object.entries(schema).findIndex(
-      ([key, guard]) => !(key in value && guard(value[key]))
-    ) === -1;
+    Object.keys(value).every((key) => key in schema) &&
+    Object.entries(schema).every(
+      ([key, guard]) => key in value && guard(value[key])
+    );
 
 export { matchExactSchema };
 export type { MatchExactSchema, MatchExactSchemaFn };

--- a/src/matchSchema.ts
+++ b/src/matchSchema.ts
@@ -48,8 +48,7 @@ type MatchSchema = <Schema extends TypeGuardSchema>(
 const matchSchema: MatchSchema =
   (schema) =>
   (value): value is never =>
-    Object.entries(schema).findIndex(([key, guard]) => !guard(value[key])) ===
-    -1;
+    Object.entries(schema).every(([key, guard]) => guard(value[key]));
 
 export { matchSchema };
 export type { MatchSchema, MatchSchemaFn };


### PR DESCRIPTION
- `guardAllIn`: `findIndex === -1` → `every`
- `guardEitherIn`: `findIndex !== -1` → `some`
- `matchSchema`: `Object.entries().findIndex()` → `.every()`
- `matchExactSchema`: same
- `isNonEmptyArray`: inline `Array.isArray` instead of `isArray` wrapper

Cleaner, fewer allocations, same semantics. All 99 tests + type tests passing.